### PR TITLE
:bug: Changed dash entry point

### DIFF
--- a/pytest_dash/wait_for.py
+++ b/pytest_dash/wait_for.py
@@ -197,7 +197,7 @@ def _wait_for_client_app_started(driver, url, wait_time=0.5, timeout=10):
         try:
             driver.get(url)
             wait_for_element_by_css_selector(
-                driver, '#_dash-app-content', timeout=wait_time
+                driver, '#react-entry-point', timeout=wait_time
             )
             return
         except TimeoutException:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dash==0.39.0
+dash==0.43.0
 selenium
 pytest
 requests


### PR DESCRIPTION
Hi I had noticed that because of #75, I couldn't run tests for my dash app.
Looks the problem happnes after dash 0.39.0
Here's the patch!!

- About the patch
  - a patch for Dash app entrypoint not available in latest dash_renderer #75
  - Changed entry point based on @HansKallekleiv 's claim

- What I did
  - changed entry point for wait_for
  - updated dash version on requirements txt to 0.43.0
